### PR TITLE
Update template models with base classes

### DIFF
--- a/Example/ios-module-architecture.xcodeproj/project.pbxproj
+++ b/Example/ios-module-architecture.xcodeproj/project.pbxproj
@@ -19,18 +19,19 @@
 		205642942062CF9600ACE96E /* Module_Definitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205642892062CF9600ACE96E /* Module_Definitions.swift */; };
 		205642952062CF9600ACE96E /* Module_Presenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2056428A2062CF9600ACE96E /* Module_Presenter.swift */; };
 		205642962062CF9600ACE96E /* Module_Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2056428B2062CF9600ACE96E /* Module_Component.swift */; };
-		47F0B99E2087B0E100CCB4DA /* SampleCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F0B9982087B0E100CCB4DA /* SampleCoordinator.swift */; };
-		47F0B99F2087B0E100CCB4DA /* SampleModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F0B9992087B0E100CCB4DA /* SampleModule.swift */; };
-		47F0B9A02087B0E100CCB4DA /* SamplePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F0B99A2087B0E100CCB4DA /* SamplePresenter.swift */; };
-		47F0B9A12087B0E100CCB4DA /* SampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F0B99B2087B0E100CCB4DA /* SampleViewController.swift */; };
-		47F0B9A22087B0E100CCB4DA /* SampleComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F0B99C2087B0E100CCB4DA /* SampleComponent.swift */; };
-		47F0B9A32087B0E100CCB4DA /* SampleDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F0B99D2087B0E100CCB4DA /* SampleDefinitions.swift */; };
 		4A7BB957059C7A7B890D1F8D /* Pods_ios_module_architecture_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 426520ED70C300A96FADBBF9 /* Pods_ios_module_architecture_Tests.framework */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		607FACEC1AFB9204008FA782 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* Tests.swift */; };
+		63F03E2620935ECA0092426F /* SampleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F03E1F20935ECA0092426F /* SampleConfiguration.swift */; };
+		63F03E2720935ECA0092426F /* SampleCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F03E2020935ECA0092426F /* SampleCoordinator.swift */; };
+		63F03E2820935ECA0092426F /* SampleModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F03E2120935ECA0092426F /* SampleModule.swift */; };
+		63F03E2920935ECA0092426F /* SamplePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F03E2220935ECA0092426F /* SamplePresenter.swift */; };
+		63F03E2A20935ECA0092426F /* SampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F03E2320935ECA0092426F /* SampleViewController.swift */; };
+		63F03E2B20935ECA0092426F /* SampleComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F03E2420935ECA0092426F /* SampleComponent.swift */; };
+		63F03E2C20935ECA0092426F /* SampleDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F03E2520935ECA0092426F /* SampleDefinitions.swift */; };
 		857B90F90B9E22E9E4C6662E /* Pods_ios_module_architecture_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E48C40356DB8E4C9AE9C97A4 /* Pods_ios_module_architecture_Example.framework */; };
 /* End PBXBuildFile section */
 
@@ -45,7 +46,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		2056426E2062CA8D00ACE96E /* ModuleArchitecture.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = ModuleArchitecture.podspec; path = ../ModuleArchitecture.podspec; sourceTree = "<group>"; };
+		2056426E2062CA8D00ACE96E /* ModuleArchitecture.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = ModuleArchitecture.podspec; path = ../ModuleArchitecture.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		205642802062CF9600ACE96E /* ViewLessModule_Presenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewLessModule_Presenter.swift; sourceTree = "<group>"; };
 		205642812062CF9600ACE96E /* ViewLessModule_Definitions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewLessModule_Definitions.swift; sourceTree = "<group>"; };
 		205642822062CF9600ACE96E /* ViewLessModule_Coordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewLessModule_Coordinator.swift; sourceTree = "<group>"; };
@@ -58,12 +59,6 @@
 		2056428A2062CF9600ACE96E /* Module_Presenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Module_Presenter.swift; sourceTree = "<group>"; };
 		2056428B2062CF9600ACE96E /* Module_Component.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Module_Component.swift; sourceTree = "<group>"; };
 		426520ED70C300A96FADBBF9 /* Pods_ios_module_architecture_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ios_module_architecture_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		47F0B9982087B0E100CCB4DA /* SampleCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleCoordinator.swift; sourceTree = "<group>"; };
-		47F0B9992087B0E100CCB4DA /* SampleModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleModule.swift; sourceTree = "<group>"; };
-		47F0B99A2087B0E100CCB4DA /* SamplePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplePresenter.swift; sourceTree = "<group>"; };
-		47F0B99B2087B0E100CCB4DA /* SampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleViewController.swift; sourceTree = "<group>"; };
-		47F0B99C2087B0E100CCB4DA /* SampleComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleComponent.swift; sourceTree = "<group>"; };
-		47F0B99D2087B0E100CCB4DA /* SampleDefinitions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleDefinitions.swift; sourceTree = "<group>"; };
 		48A640D003D4618D4568B33F /* Pods-ios-module-architecture_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios-module-architecture_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ios-module-architecture_Example/Pods-ios-module-architecture_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		4EB38509D25141BAC263B3E8 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* ios-module-architecture_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ios-module-architecture_Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -75,6 +70,13 @@
 		607FACE51AFB9204008FA782 /* ios-module-architecture_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ios-module-architecture_Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		607FACEB1AFB9204008FA782 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
+		63F03E1F20935ECA0092426F /* SampleConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleConfiguration.swift; sourceTree = "<group>"; };
+		63F03E2020935ECA0092426F /* SampleCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleCoordinator.swift; sourceTree = "<group>"; };
+		63F03E2120935ECA0092426F /* SampleModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleModule.swift; sourceTree = "<group>"; };
+		63F03E2220935ECA0092426F /* SamplePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplePresenter.swift; sourceTree = "<group>"; };
+		63F03E2320935ECA0092426F /* SampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleViewController.swift; sourceTree = "<group>"; };
+		63F03E2420935ECA0092426F /* SampleComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleComponent.swift; sourceTree = "<group>"; };
+		63F03E2520935ECA0092426F /* SampleDefinitions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleDefinitions.swift; sourceTree = "<group>"; };
 		B5B95B35FD5812AF2CB58C75 /* Pods-ios-module-architecture_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios-module-architecture_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ios-module-architecture_Tests/Pods-ios-module-architecture_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		D10561CA5D123E0EF8F23BDF /* Pods-ios-module-architecture_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios-module-architecture_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ios-module-architecture_Tests/Pods-ios-module-architecture_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		D6EA043D90A591C8535C5A25 /* Pods-ios-module-architecture_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios-module-architecture_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-ios-module-architecture_Example/Pods-ios-module-architecture_Example.release.xcconfig"; sourceTree = "<group>"; };
@@ -208,12 +210,13 @@
 		631F57A7208656970029AA11 /* Sample */ = {
 			isa = PBXGroup;
 			children = (
-				47F0B9982087B0E100CCB4DA /* SampleCoordinator.swift */,
-				47F0B9992087B0E100CCB4DA /* SampleModule.swift */,
-				47F0B99A2087B0E100CCB4DA /* SamplePresenter.swift */,
-				47F0B99B2087B0E100CCB4DA /* SampleViewController.swift */,
-				47F0B99C2087B0E100CCB4DA /* SampleComponent.swift */,
-				47F0B99D2087B0E100CCB4DA /* SampleDefinitions.swift */,
+				63F03E1F20935ECA0092426F /* SampleConfiguration.swift */,
+				63F03E2020935ECA0092426F /* SampleCoordinator.swift */,
+				63F03E2120935ECA0092426F /* SampleModule.swift */,
+				63F03E2220935ECA0092426F /* SamplePresenter.swift */,
+				63F03E2320935ECA0092426F /* SampleViewController.swift */,
+				63F03E2420935ECA0092426F /* SampleComponent.swift */,
+				63F03E2520935ECA0092426F /* SampleDefinitions.swift */,
 			);
 			path = Sample;
 			sourceTree = "<group>";
@@ -456,23 +459,24 @@
 			buildActionMask = 2147483647;
 			files = (
 				205642962062CF9600ACE96E /* Module_Component.swift in Sources */,
-				47F0B99F2087B0E100CCB4DA /* SampleModule.swift in Sources */,
 				205642912062CF9600ACE96E /* Module_Module.swift in Sources */,
 				2056428C2062CF9600ACE96E /* ViewLessModule_Presenter.swift in Sources */,
 				205642952062CF9600ACE96E /* Module_Presenter.swift in Sources */,
-				47F0B9A02087B0E100CCB4DA /* SamplePresenter.swift in Sources */,
-				47F0B9A12087B0E100CCB4DA /* SampleViewController.swift in Sources */,
+				63F03E2A20935ECA0092426F /* SampleViewController.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
-				47F0B99E2087B0E100CCB4DA /* SampleCoordinator.swift in Sources */,
 				2056428E2062CF9600ACE96E /* ViewLessModule_Coordinator.swift in Sources */,
-				47F0B9A32087B0E100CCB4DA /* SampleDefinitions.swift in Sources */,
 				205642922062CF9600ACE96E /* Module_Coordinator.swift in Sources */,
 				2056428F2062CF9600ACE96E /* ViewLessModule_Module.swift in Sources */,
+				63F03E2720935ECA0092426F /* SampleCoordinator.swift in Sources */,
 				205642942062CF9600ACE96E /* Module_Definitions.swift in Sources */,
-				47F0B9A22087B0E100CCB4DA /* SampleComponent.swift in Sources */,
+				63F03E2C20935ECA0092426F /* SampleDefinitions.swift in Sources */,
+				63F03E2920935ECA0092426F /* SamplePresenter.swift in Sources */,
 				205642932062CF9600ACE96E /* Module_Configuration.swift in Sources */,
+				63F03E2B20935ECA0092426F /* SampleComponent.swift in Sources */,
+				63F03E2820935ECA0092426F /* SampleModule.swift in Sources */,
 				205642902062CF9600ACE96E /* Module_ViewController.swift in Sources */,
 				2056428D2062CF9600ACE96E /* ViewLessModule_Definitions.swift in Sources */,
+				63F03E2620935ECA0092426F /* SampleConfiguration.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/ios-module-architecture/Sample/SampleComponent.swift
+++ b/Example/ios-module-architecture/Sample/SampleComponent.swift
@@ -15,13 +15,14 @@ final class SampleComponent: UIView, Component {
 extension SampleComponent {
     
     enum Configuration {
-
+        case build(SampleConfiguration)
     }
     
     func render(configuration: Configuration) {
 
         switch configuration {
-
+        case .build(let configuration):
+            print(configuration)
         }
     }
 }

--- a/Example/ios-module-architecture/Sample/SampleConfiguration.swift
+++ b/Example/ios-module-architecture/Sample/SampleConfiguration.swift
@@ -1,0 +1,5 @@
+import ModuleArchitecture
+
+struct SampleConfiguration {
+    
+}

--- a/Example/ios-module-architecture/Sample/SampleCoordinator.swift
+++ b/Example/ios-module-architecture/Sample/SampleCoordinator.swift
@@ -1,21 +1,13 @@
 import ModuleArchitecture
 
-final class SampleCoordinator: SampleCoordinatorType {
+final class SampleCoordinator: Coordinator<SamplePresenterType>, SampleCoordinatorType {
     
     let viewController: SampleViewControllerType
-    private let presenter: SamplePresenterType
-    
-    private(set) var currentChild: Coordinator?
-    
+
     init(presenter: SamplePresenterType, viewController: SampleViewControllerType) {
-        
-        self.presenter = presenter
+
         self.viewController = viewController
-    }
-    
-    func start() {
-        
-        self.presenter.start()
+        super.init(presenter: presenter)
     }
 }
 

--- a/Example/ios-module-architecture/Sample/SampleDefinitions.swift
+++ b/Example/ios-module-architecture/Sample/SampleDefinitions.swift
@@ -2,17 +2,17 @@ import ModuleArchitecture
 
 // Builder object that configures the module and returns a coordinator.
 // A module should always be instantiated via the createCoordinator method.
-protocol SampleModuleType: Module {
+protocol SampleModuleType: ModuleType {
 
     func createCoordinator() -> SampleCoordinatorType
 }
 
-protocol SampleCoordinatorType: Coordinator {
+protocol SampleCoordinatorType: CoordinatorType {
 
     var viewController: SampleViewControllerType { get }
 }
 
-protocol SamplePresenterType: Presenter, SampleViewControllerDelegate {
+protocol SamplePresenterType: PresenterType, SampleViewControllerDelegate {
 
     var delegate: SamplePresenterDelegate? { get set }
 }
@@ -26,5 +26,5 @@ protocol SamplePresenterView: AnyObject {
     
     // This is the communication point from presenter to view controller.
     // You can change the name for something more contextual if needed.
-    //func render(configuration: SampleConfiguration)
+    func render(configuration: SampleConfiguration)
 }

--- a/Example/ios-module-architecture/Sample/SampleModule.swift
+++ b/Example/ios-module-architecture/Sample/SampleModule.swift
@@ -1,6 +1,6 @@
 import ModuleArchitecture
 
-final class SampleModule: SampleModuleType {
+final class SampleModule: Module, SampleModuleType {
     
     func createCoordinator() -> SampleCoordinatorType {
         

--- a/Example/ios-module-architecture/Sample/SamplePresenter.swift
+++ b/Example/ios-module-architecture/Sample/SamplePresenter.swift
@@ -4,13 +4,13 @@ protocol SamplePresenterDelegate: AnyObject {
     
 }
 
-final class SamplePresenter: SamplePresenterType {
+final class SamplePresenter: Presenter, SamplePresenterType {
     
     weak var viewController: SamplePresenterView?
     weak var delegate: SamplePresenterDelegate?
-    
-    func start() {
-        
+
+    override func start() {
+        //
     }
 }
 

--- a/Example/ios-module-architecture/Sample/SampleViewController.swift
+++ b/Example/ios-module-architecture/Sample/SampleViewController.swift
@@ -25,8 +25,8 @@ extension SampleViewController: SamplePresenterView {
     
     // This is the communication point from presenter to view controller.
     // You can change the name for something more contextual if needed.
-//    func render(configuration: SampleConfiguration) {
-//
-//        self.component.render(configuration: .build(configuration))
-//    }
+    func render(configuration: SampleConfiguration) {
+
+        self.component.render(configuration: .build(configuration))
+    }
 }

--- a/Example/ios-module-architecture/Templates/Module_/Module_Coordinator.swift
+++ b/Example/ios-module-architecture/Templates/Module_/Module_Coordinator.swift
@@ -1,21 +1,13 @@
 import ModuleArchitecture
 
-final class Module_Coordinator: Module_CoordinatorType {
+final class Module_Coordinator: Coordinator<Module_PresenterType>, Module_CoordinatorType {
     
     let viewController: Module_ViewControllerType
-    private let presenter: Module_PresenterType
-    
-    private(set) var currentChild: Coordinator?
-    
+
     init(presenter: Module_PresenterType, viewController: Module_ViewControllerType) {
-        
-        self.presenter = presenter
+
         self.viewController = viewController
-    }
-    
-    func start() {
-        
-        self.presenter.start()
+        super.init(presenter: presenter)
     }
 }
 

--- a/Example/ios-module-architecture/Templates/Module_/Module_Definitions.swift
+++ b/Example/ios-module-architecture/Templates/Module_/Module_Definitions.swift
@@ -2,17 +2,17 @@ import ModuleArchitecture
 
 // Builder object that configures the module and returns a coordinator.
 // A module should always be instantiated via the createCoordinator method.
-protocol Module_ModuleType: Module {
+protocol Module_ModuleType: ModuleType {
 
     func createCoordinator() -> Module_CoordinatorType
 }
 
-protocol Module_CoordinatorType: Coordinator {
+protocol Module_CoordinatorType: CoordinatorType {
 
     var viewController: Module_ViewControllerType { get }
 }
 
-protocol Module_PresenterType: Presenter, Module_ViewControllerDelegate {
+protocol Module_PresenterType: PresenterType, Module_ViewControllerDelegate {
 
     var delegate: Module_PresenterDelegate? { get set }
 }

--- a/Example/ios-module-architecture/Templates/Module_/Module_Module.swift
+++ b/Example/ios-module-architecture/Templates/Module_/Module_Module.swift
@@ -1,6 +1,6 @@
 import ModuleArchitecture
 
-final class Module_Module: Module_ModuleType {
+final class Module_Module: Module, Module_ModuleType {
     
     func createCoordinator() -> Module_CoordinatorType {
         

--- a/Example/ios-module-architecture/Templates/Module_/Module_Presenter.swift
+++ b/Example/ios-module-architecture/Templates/Module_/Module_Presenter.swift
@@ -4,13 +4,13 @@ protocol Module_PresenterDelegate: AnyObject {
     
 }
 
-final class Module_Presenter: Module_PresenterType {
+final class Module_Presenter: Presenter, Module_PresenterType {
     
     weak var viewController: Module_PresenterView?
     weak var delegate: Module_PresenterDelegate?
-    
-    func start() {
-        
+
+    override func start() {
+        //
     }
 }
 

--- a/Example/ios-module-architecture/Templates/ViewLessModule_/ViewLessModule_Coordinator.swift
+++ b/Example/ios-module-architecture/Templates/ViewLessModule_/ViewLessModule_Coordinator.swift
@@ -1,20 +1,7 @@
 import ModuleArchitecture
 
-final class ViewLessModule_Coordinator: ViewLessModule_CoordinatorType {
-    
-    private let presenter: ViewLessModule_PresenterType
-    
-    private(set) var currentChild: Coordinator?
-    
-    init(presenter: ViewLessModule_PresenterType) {
+final class ViewLessModule_Coordinator: Coordinator<ViewLessModule_PresenterType>, ViewLessModule_CoordinatorType {
 
-        self.presenter = presenter
-    }
-    
-    func start() {
-        
-        self.presenter.start()
-    }
 }
 
 extension ViewLessModule_Coordinator: ViewLessModule_PresenterDelegate {

--- a/Example/ios-module-architecture/Templates/ViewLessModule_/ViewLessModule_Definitions.swift
+++ b/Example/ios-module-architecture/Templates/ViewLessModule_/ViewLessModule_Definitions.swift
@@ -2,16 +2,16 @@ import ModuleArchitecture
 
 // Builder object that configures the module and returns a coordinator.
 // A module should always be instantiated via the createCoordinator method.
-protocol ViewLessModule_ModuleType: Module {
+protocol ViewLessModule_ModuleType: ModuleType {
 
     func createCoordinator() -> ViewLessModule_CoordinatorType
 }
 
-protocol ViewLessModule_CoordinatorType: Coordinator {
+protocol ViewLessModule_CoordinatorType: CoordinatorType {
     
 }
 
-protocol ViewLessModule_PresenterType: Presenter {
+protocol ViewLessModule_PresenterType: PresenterType {
     
     var delegate: ViewLessModule_PresenterDelegate? { get set }
 }

--- a/Example/ios-module-architecture/Templates/ViewLessModule_/ViewLessModule_Module.swift
+++ b/Example/ios-module-architecture/Templates/ViewLessModule_/ViewLessModule_Module.swift
@@ -1,6 +1,6 @@
 import ModuleArchitecture
 
-final class ViewLessModule_Module: ViewLessModule_ModuleType {
+final class ViewLessModule_Module: Module, ViewLessModule_ModuleType {
     
     func createCoordinator() -> ViewLessModule_CoordinatorType {
         

--- a/Example/ios-module-architecture/Templates/ViewLessModule_/ViewLessModule_Presenter.swift
+++ b/Example/ios-module-architecture/Templates/ViewLessModule_/ViewLessModule_Presenter.swift
@@ -4,11 +4,11 @@ protocol ViewLessModule_PresenterDelegate: AnyObject {
     
 }
 
-final class ViewLessModule_Presenter: ViewLessModule_PresenterType {
+final class ViewLessModule_Presenter: Presenter, ViewLessModule_PresenterType {
     
     weak var delegate: ViewLessModule_PresenterDelegate?
-    
-    func start() {
-        
+
+    override func start() {
+        //
     }
 }

--- a/ModuleArchitecture.podspec
+++ b/ModuleArchitecture.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'ModuleArchitecture'
-  s.version          = '0.8.0'
+  s.version          = '0.9.0'
   s.summary          = 'iOS Architecture'
   s.description      = <<-DESC
   Protocols that define a module based iOS Architecture

--- a/ModuleArchitecture/Classes/Protocols/Component.swift
+++ b/ModuleArchitecture/Classes/Protocols/Component.swift
@@ -1,4 +1,5 @@
 public protocol Component: AnyObject {
+    
     associatedtype Configuration
     func render(configuration: Configuration)
 }

--- a/ModuleArchitecture/Classes/Protocols/Coordinator.swift
+++ b/ModuleArchitecture/Classes/Protocols/Coordinator.swift
@@ -1,4 +1,38 @@
-public protocol Coordinator: AnyObject {
-    var currentChild: Coordinator? { get }
+public protocol CoordinatorType: AnyObject {
+    
     func start()
+    func attach(_ child: CoordinatorType)
+    func detach(_ child: CoordinatorType)
+}
+
+open class Coordinator<Presentable>: CoordinatorType {
+
+    private var children: [CoordinatorType] = []
+
+    private let presenterType: PresenterType
+
+    public let presenter: Presentable
+
+    public init(presenter: Presentable) {
+
+        guard let presenterType = presenter as? PresenterType else { fatalError() }
+        self.presenterType = presenterType
+        self.presenter = presenter
+    }
+
+    open func start() {
+
+        self.presenterType.start()
+    }
+
+    public func attach(_ child: CoordinatorType) {
+
+        self.children.append(child)
+    }
+
+    public func detach(_ child: CoordinatorType) {
+
+        guard let index = self.children.index(where: { $0 === child }) else { return }
+        self.children.remove(at: index)
+    }
 }

--- a/ModuleArchitecture/Classes/Protocols/Module.swift
+++ b/ModuleArchitecture/Classes/Protocols/Module.swift
@@ -1,3 +1,7 @@
-public protocol Module: AnyObject {
+public protocol ModuleType: AnyObject {
     
+}
+
+open class Module: ModuleType {
+
 }

--- a/ModuleArchitecture/Classes/Protocols/Presenter.swift
+++ b/ModuleArchitecture/Classes/Protocols/Presenter.swift
@@ -1,3 +1,14 @@
-public protocol Presenter: AnyObject {
+public protocol PresenterType: AnyObject {
     func start()
+}
+
+open class Presenter: PresenterType {
+
+    public init() {
+        //
+    }
+
+    open func start() {
+        //
+    }
 }

--- a/tooling/Module.xctemplate/Default/___FILEBASENAME___Coordinator.swift
+++ b/tooling/Module.xctemplate/Default/___FILEBASENAME___Coordinator.swift
@@ -1,20 +1,7 @@
 import ModuleArchitecture
 
-final class ___VARIABLE_productName___Coordinator: ___VARIABLE_productName___CoordinatorType {
-    
-    private let presenter: ___VARIABLE_productName___PresenterType
-    
-    private(set) var currentChild: Coordinator?
-    
-    init(presenter: ___VARIABLE_productName___PresenterType) {
+final class ___VARIABLE_productName___Coordinator: Coordinator<___VARIABLE_productName___PresenterType>, ___VARIABLE_productName___CoordinatorType {
 
-        self.presenter = presenter
-    }
-    
-    func start() {
-        
-        self.presenter.start()
-    }
 }
 
 extension ___VARIABLE_productName___Coordinator: ___VARIABLE_productName___PresenterDelegate {

--- a/tooling/Module.xctemplate/Default/___FILEBASENAME___Definitions.swift
+++ b/tooling/Module.xctemplate/Default/___FILEBASENAME___Definitions.swift
@@ -2,16 +2,16 @@ import ModuleArchitecture
 
 // Builder object that configures the module and returns a coordinator.
 // A module should always be instantiated via the createCoordinator method.
-protocol ___VARIABLE_productName___ModuleType: Module {
+protocol ___VARIABLE_productName___ModuleType: ModuleType {
 
     func createCoordinator() -> ___VARIABLE_productName___CoordinatorType
 }
 
-protocol ___VARIABLE_productName___CoordinatorType: Coordinator {
+protocol ___VARIABLE_productName___CoordinatorType: CoordinatorType {
     
 }
 
-protocol ___VARIABLE_productName___PresenterType: Presenter {
+protocol ___VARIABLE_productName___PresenterType: PresenterType {
     
     var delegate: ___VARIABLE_productName___PresenterDelegate? { get set }
 }

--- a/tooling/Module.xctemplate/Default/___FILEBASENAME___Module.swift
+++ b/tooling/Module.xctemplate/Default/___FILEBASENAME___Module.swift
@@ -1,6 +1,6 @@
 import ModuleArchitecture
 
-final class ___VARIABLE_productName___Module: ___VARIABLE_productName___ModuleType {
+final class ___VARIABLE_productName___Module: Module, ___VARIABLE_productName___ModuleType {
     
     func createCoordinator() -> ___VARIABLE_productName___CoordinatorType {
         

--- a/tooling/Module.xctemplate/Default/___FILEBASENAME___Presenter.swift
+++ b/tooling/Module.xctemplate/Default/___FILEBASENAME___Presenter.swift
@@ -4,11 +4,11 @@ protocol ___VARIABLE_productName___PresenterDelegate: AnyObject {
     
 }
 
-final class ___VARIABLE_productName___Presenter: ___VARIABLE_productName___PresenterType {
+final class ___VARIABLE_productName___Presenter: Presenter, ___VARIABLE_productName___PresenterType {
     
     weak var delegate: ___VARIABLE_productName___PresenterDelegate?
-    
-    func start() {
-        
+
+    override func start() {
+        //
     }
 }

--- a/tooling/Module.xctemplate/ownsView/___FILEBASENAME___Component.swift
+++ b/tooling/Module.xctemplate/ownsView/___FILEBASENAME___Component.swift
@@ -15,13 +15,14 @@ final class ___VARIABLE_productName___Component: UIView, Component {
 extension ___VARIABLE_productName___Component {
     
     enum Configuration {
-
+        case build(___VARIABLE_productName___Configuration)
     }
     
     func render(configuration: Configuration) {
 
         switch configuration {
-
+        case .build(let configuration):
+            print(configuration)
         }
     }
 }

--- a/tooling/Module.xctemplate/ownsView/___FILEBASENAME___Configuration.swift
+++ b/tooling/Module.xctemplate/ownsView/___FILEBASENAME___Configuration.swift
@@ -1,0 +1,5 @@
+import ModuleArchitecture
+
+struct ___VARIABLE_productName___Configuration {
+    
+}

--- a/tooling/Module.xctemplate/ownsView/___FILEBASENAME___Coordinator.swift
+++ b/tooling/Module.xctemplate/ownsView/___FILEBASENAME___Coordinator.swift
@@ -1,21 +1,13 @@
 import ModuleArchitecture
 
-final class ___VARIABLE_productName___Coordinator: ___VARIABLE_productName___CoordinatorType {
+final class ___VARIABLE_productName___Coordinator: Coordinator<___VARIABLE_productName___PresenterType>, ___VARIABLE_productName___CoordinatorType {
     
     let viewController: ___VARIABLE_productName___ViewControllerType
-    private let presenter: ___VARIABLE_productName___PresenterType
-    
-    private(set) var currentChild: Coordinator?
-    
+
     init(presenter: ___VARIABLE_productName___PresenterType, viewController: ___VARIABLE_productName___ViewControllerType) {
-        
-        self.presenter = presenter
+
         self.viewController = viewController
-    }
-    
-    func start() {
-        
-        self.presenter.start()
+        super.init(presenter: presenter)
     }
 }
 

--- a/tooling/Module.xctemplate/ownsView/___FILEBASENAME___Definitions.swift
+++ b/tooling/Module.xctemplate/ownsView/___FILEBASENAME___Definitions.swift
@@ -2,17 +2,17 @@ import ModuleArchitecture
 
 // Builder object that configures the module and returns a coordinator.
 // A module should always be instantiated via the createCoordinator method.
-protocol ___VARIABLE_productName___ModuleType: Module {
+protocol ___VARIABLE_productName___ModuleType: ModuleType {
 
     func createCoordinator() -> ___VARIABLE_productName___CoordinatorType
 }
 
-protocol ___VARIABLE_productName___CoordinatorType: Coordinator {
+protocol ___VARIABLE_productName___CoordinatorType: CoordinatorType {
 
     var viewController: ___VARIABLE_productName___ViewControllerType { get }
 }
 
-protocol ___VARIABLE_productName___PresenterType: Presenter, ___VARIABLE_productName___ViewControllerDelegate {
+protocol ___VARIABLE_productName___PresenterType: PresenterType, ___VARIABLE_productName___ViewControllerDelegate {
 
     var delegate: ___VARIABLE_productName___PresenterDelegate? { get set }
 }
@@ -26,5 +26,5 @@ protocol ___VARIABLE_productName___PresenterView: AnyObject {
     
     // This is the communication point from presenter to view controller.
     // You can change the name for something more contextual if needed.
-    //func render(configuration: ___VARIABLE_productName___Configuration)
+    func render(configuration: ___VARIABLE_productName___Configuration)
 }

--- a/tooling/Module.xctemplate/ownsView/___FILEBASENAME___Module.swift
+++ b/tooling/Module.xctemplate/ownsView/___FILEBASENAME___Module.swift
@@ -1,6 +1,6 @@
 import ModuleArchitecture
 
-final class ___VARIABLE_productName___Module: ___VARIABLE_productName___ModuleType {
+final class ___VARIABLE_productName___Module: Module, ___VARIABLE_productName___ModuleType {
     
     func createCoordinator() -> ___VARIABLE_productName___CoordinatorType {
         

--- a/tooling/Module.xctemplate/ownsView/___FILEBASENAME___Presenter.swift
+++ b/tooling/Module.xctemplate/ownsView/___FILEBASENAME___Presenter.swift
@@ -4,13 +4,13 @@ protocol ___VARIABLE_productName___PresenterDelegate: AnyObject {
     
 }
 
-final class ___VARIABLE_productName___Presenter: ___VARIABLE_productName___PresenterType {
+final class ___VARIABLE_productName___Presenter: Presenter, ___VARIABLE_productName___PresenterType {
     
     weak var viewController: ___VARIABLE_productName___PresenterView?
     weak var delegate: ___VARIABLE_productName___PresenterDelegate?
-    
-    func start() {
-        
+
+    override func start() {
+        //
     }
 }
 

--- a/tooling/Module.xctemplate/ownsView/___FILEBASENAME___ViewController.swift
+++ b/tooling/Module.xctemplate/ownsView/___FILEBASENAME___ViewController.swift
@@ -25,8 +25,8 @@ extension ___VARIABLE_productName___ViewController: ___VARIABLE_productName___Pr
     
     // This is the communication point from presenter to view controller.
     // You can change the name for something more contextual if needed.
-//    func render(configuration: ___VARIABLE_productName___Configuration) {
-//
-//        self.component.render(configuration: .build(configuration))
-//    }
+    func render(configuration: ___VARIABLE_productName___Configuration) {
+
+        self.component.render(configuration: .build(configuration))
+    }
 }


### PR DESCRIPTION
Add base classes for `Presenter`, `Coordinator` and `Module` layers.

Using base classes will allow creating generic structures in the future without the need of propagating associated types through the application layers.